### PR TITLE
Downgrade click to circumvent ValueError

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ scandir==1.10.0
 progressbar2==3.42.0
 redis==3.3.5
 rq==1.1.0
+click==7.1.2


### PR DESCRIPTION
Raises ValueError: 'default' must be a list when 'multiple' is true. on the latest click package, so reducing it to something lower fixes it.
```python
Traceback (most recent call last):
  File "/usr/bin/rq-dashboard", line 11, in <module>
    load_entry_point('rq-dashboard==0.6.1', 'console_scripts', 'rq-dashboard')()
  File "/usr/lib/python3.8/site-packages/pkg_resources/__init__.py", line 490, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/usr/lib/python3.8/site-packages/pkg_resources/__init__.py", line 2862, in load_entry_point
    return ep.load()
  File "/usr/lib/python3.8/site-packages/pkg_resources/__init__.py", line 2462, in load
    return self.resolve()
  File "/usr/lib/python3.8/site-packages/pkg_resources/__init__.py", line 2468, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/usr/lib/python3.8/site-packages/rq_dashboard/cli.py", line 112, in <module>
    def run(
  File "/usr/lib/python3.8/site-packages/click/decorators.py", line 247, in decorator
    _param_memo(f, OptionClass(param_decls, **option_attrs))
  File "/usr/lib/python3.8/site-packages/click/core.py", line 2482, in __init__
    super().__init__(param_decls, type=type, multiple=multiple, **attrs)
  File "/usr/lib/python3.8/site-packages/click/core.py", line 2108, in __init__
    raise ValueError(
ValueError: 'default' must be a list when 'multiple' is true.
```